### PR TITLE
Adding missing property chainEndpoint to endpointConfig.js

### DIFF
--- a/public/static/endpointConfig.js
+++ b/public/static/endpointConfig.js
@@ -1,12 +1,9 @@
 const backendUrl='http://localhost:5001';
 const nodeAddress = '0x4E7eA0919a88f9103e6eE5323D24A1073d79fb0D';
 const rnsDomain = 'dev.rsk.co';
-
+const chainEndpoint = 'http://localhost:4444';
 
 window.luminoUrl = backendUrl;
 window.nodeAddress= nodeAddress;
 window.rnsDomain = rnsDomain;
-
-
-
-
+window.chainEndpoint = chainEndpoint;


### PR DESCRIPTION
This change basically adds a missing property to the endpointConfig.js used by lumino node later. If we don't put this here later in the generated ui it will not be correctly mapped and the ui will fail to load.